### PR TITLE
Fix corruption of .pkl files on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pkl binary


### PR DESCRIPTION
On Windows, .pkl files get corrupted due to the conversion of line endings when cloning pymol from github.

For example, the Electrostatics demo fails with 
```
Load-Error: Unable to load file 'X:\Python37\lib\site-packages\pymol\pymol_path\data/demo/pept.pkl'.
Selector-Error: Invalid selection name "pept".
( pept )<--
Exception in thread Thread-3:
Traceback (most recent call last):
  File "X:\Python37\lib\threading.py", line 917, in _bootstrap_inner
    self.run()
  File "X:\Python37\lib\threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "X:\Python37\lib\site-packages\pymol\wizard\demo.py", line 378, in elec
    self.cmd.hide("(pept)")
  File "X:\Python37\lib\site-packages\pymol\viewing.py", line 665, in hide
    return _showhide(representation, selection, 0, _self)
  File "X:\Python37\lib\site-packages\pymol\viewing.py", line 551, in _showhide
    if _self._raising(r,_self): raise QuietException
pymol.parsing.QuietException
```